### PR TITLE
relative URLs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseurl = "http://transparentstatistics.org/"
+relativeURLs = true
 languageCode = "en-us"
 title = "Transparent Statistics in HCI"
 theme = "hugo-lithium"


### PR DESCRIPTION
I used this for viewing the site locally and on my own server without needing to worry about changing the base URL.

Let's wait a few days until the blog post's traffic dies down. Then, might as well use this setting.